### PR TITLE
新增 cookiestxt 的支援

### DIFF
--- a/packages/novel-downloader-cli/package.json
+++ b/packages/novel-downloader-cli/package.json
@@ -74,7 +74,8 @@
     "novel-downloader": "^2.0.38",
     "ts-type": "^3.0.1",
     "tslib": "^2.6.2",
-    "yargs": "^17.7.2"
+    "yargs": "^17.7.2",
+    "netscape-cookies-parser": "^1.0.2"
   },
   "engines": {
     "node": ">= 13"

--- a/packages/novel-downloader/src/site/index.ts
+++ b/packages/novel-downloader/src/site/index.ts
@@ -257,7 +257,6 @@ export class NovelSite implements NovelSite.INovelSite
 
 		optionsRuntime.startIndex = optionsRuntime.startIndex || 0;
 
-		// @ts-ignore
 		optionsRuntime.optionsJSDOM = createOptionsJSDOM(optionsRuntime.optionsJSDOM);
 
 
@@ -605,7 +604,9 @@ export namespace NovelSite
 
 		outputDir?: string,
 		cwd?: string,
-
+		optionsJSDOM?: IFromUrlOptions & IOptionsJSDOM & {
+			cookieJar?: Partial<LazyCookieJar>,
+		}
 	} & IOptionsPlus;
 
 	export const enum EnumPathNovelStyle

--- a/yarn.lock
+++ b/yarn.lock
@@ -4226,6 +4226,11 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
+netscape-cookies-parser@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/netscape-cookies-parser/-/netscape-cookies-parser-1.0.2.tgz#06e82b6df8ed63961b9a8e5d3eb78967713042c6"
+  integrity sha512-ESacct66yI9q2V5voU179o1Y6kInEaFNn91BRSVOFFdwDbss7e4JOd9RIOThYZZUfh1uFMPnq/X36GEYI8nqtg==
+
 no-case@^2.2.0:
   version "2.3.2"
   resolved "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"


### PR DESCRIPTION
cookies.txt 是  Netscape HTTP Cookie File  https://curl.haxx.se/rfc/cookie_spec.html 的格式, firefox和chrome都有方便的擴展髒產額導出出來, 下一步可以考慮導入到 https://github.com/bluelovers/novel-opds-now